### PR TITLE
IGV Viewer for off-targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guidescan-frontend",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",

--- a/src/jobs/completedPage.js
+++ b/src/jobs/completedPage.js
@@ -38,15 +38,16 @@ function JobCompletedPage(props) {
 
     useEffect(() => {
         function onLoadSuccess(response) {
-            updateResults(response.data);
-            updateResultsState(JobResultsState.RECEIVED);
-
             if (props.jobType === "standard") {
                 updateOrganism(response.data[0][0].organism);
                 const genomicRegion = response.data[0][0];
                 const defaultCoordsString = genomicRegion["chromosome-name"] + ":" + genomicRegion["coords"][1] + "-" + genomicRegion["coords"][2];
                 updateCoords(defaultCoordsString);
+            } else if (props.jobType == "grna") {
+                updateOrganism(response.data[0].organism);
             }
+            updateResults(response.data);
+            updateResultsState(JobResultsState.RECEIVED);
         }
 
         function onLoadFailure(response) {
@@ -90,7 +91,7 @@ function JobCompletedPage(props) {
     if (!show_results) {
       if (props.jobType === "grna") {
         rendering = (
-          <GrnaJobResultsTable id={props.id} resultsState={results_state} results={results}/>
+          <GrnaJobResultsTable id={props.id} organism={organism} resultsState={results_state} results={results}/>
         );
       } else if (props.jobType === "library") {
         rendering = null;
@@ -103,7 +104,7 @@ function JobCompletedPage(props) {
               ) : null
             }
             <hr/> 
-            <JobResultsTable id={props.id} resultsState={results_state} results={results}/>
+            <JobResultsTable id={props.id} organism={organism} resultsState={results_state} results={results}/>
           </>
         );
       }


### PR DESCRIPTION
The coordinate entry for each off-target is now a link to the IGV Viewer, opened in a new window. This is partly to easily allow us to proceed with finding out if anything needs to change in the off-target information that is reported (1-off errors etc). This should also be helpful for the users.

A lot of tweaks here have to do with the fact that the organism name needs to be passed from the top-level component all the way down to the column formatter. There are probably more concise ways to do this, but I could think of no better way than to make functions where initially we had constants, and pass the organism name at each stage. I've checked this locally and it works as expected.

This functionality relies on a corresponding change to the Web API that is available in version 2.0.5 and above (A PR for which will be opened separately).