### PR TITLE
Fixes for off-target coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guidescan-frontend",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",

--- a/src/jobs/resultsTable.js
+++ b/src/jobs/resultsTable.js
@@ -127,22 +127,28 @@ function floatFormatter(precision) {
 }
 
 function offTargetCoordinatesFormatter(cell, row, rowIndex, { organism }) {
-  let startPosition = null;
-  let endPosition = null;
-  const direction = cell.direction === "positive" ? "+" : "-";
-  
-  if (direction === "+") {
-    startPosition = cell.position;
-    endPosition   = startPosition + 23;
-  } else {
-    endPosition   = cell.position;
-    startPosition = endPosition - 23;
-  }
+    let startPosition = null;
+    let endPosition = null;
+    const direction = cell.direction === "positive" ? "+" : "-";
 
-  const linkText = `chr${cell.chromosome}:${startPosition}-${endPosition}:${direction}`;
-  const linkUrl = `https://igv.org/app/?genome=${organism}&locus=${linkText}`;
+    if (direction === "+") {
+        /* For + strand, position denotes the (0-indexed, inclusive) end of the match
+           Convert this to (1-indexed, inclusive) */
+        endPosition = cell.position + 1;
+        /* The start index (1-indexed, inclusive) is end - len(seq_including_pam) + 1 */
+        startPosition = endPosition - 22;
+    } else {
+        /* For - strand, position denotes the (0-indexed, inclusive) start of the match
+           Convert this to (1-indexed, inclusive) */
+        startPosition = cell.position + 1;
+        /* The end index (1-indexed, inclusive) is start + len(seq_including_pam) - 1 */
+        endPosition = startPosition + 22;
+    }
 
-  return <a target="_blank" href={linkUrl}>{linkText}</a>;
+    const linkText = `chr${cell.chromosome}:${startPosition}-${endPosition}:${direction}`;
+    const linkUrl = `https://igv.org/app/?genome=${organism}&locus=${linkText}`;
+
+    return <a target="_blank" href={linkUrl}>{linkText}</a>;
 }
 
 const OffTargetResultsTableColumns = (organism) => {


### PR DESCRIPTION
Off-target coordinates were displayed incorrectly. This tweak in calculation should allow for correct display/linking of the off-targets, as can be specified by following the link to the IGV browser for any off-target.